### PR TITLE
Fix `main` entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "git://github.com/dominictarr/assertions.git"
   },
-  "main": "./assert.js",
+  "main": "./index.js",
   "scripts": {
     "test": "meta-test test/*.js"
   },


### PR DESCRIPTION
There is no `assert.js` file. The module resolve algorithm is very forgiving at the moment and also tries to resolve the `index.js` file in a directory even though the `main` entry is invalid. That's why this currently works.

This could likely change for Node.js v12 (https://github.com/nodejs/node/pull/26823) and it would be great to fix this.