### PR TITLE
Fix package.json main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "git://github.com/dominictarr/assertions.git"
   },
-  "main": "./assert.js",
+  "main": "./index.js",
   "scripts": {
     "test": "meta-test test/*.js"
   },


### PR DESCRIPTION
Currently this package depends on the implicit fall-through to `index.js`
when the main field is set to a non-existing file. This change makes it clear
which file will be used.

See: https://github.com/nodejs/node/pull/26823